### PR TITLE
feat: add perimeter:terminate command for graceful monitoring daemon shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,35 @@ Options:
 - `--duration=3600` - Duration in seconds (default: indefinite)
 - `--services=clamav,falco` - Focus on specific security services (comma-separated)
 
+#### Daemon Management
+
+For production deployments, monitoring should be run as a daemon using supervisor. The terminate command allows for graceful shutdown during deployments:
+
+```bash
+# Terminate running monitoring processes (for deployment scripts)
+php artisan perimeter:terminate
+
+# Terminate with custom wait time for graceful shutdown
+php artisan perimeter:terminate --wait=10
+```
+
+This is particularly useful with supervisor configuration for automatic restart after deployments:
+
+```ini
+[program:perimeter-monitor]
+command=php /path/to/your/artisan perimeter:monitor
+autostart=true
+autorestart=true
+user=www-data
+redirect_stderr=true
+stdout_logfile=/var/log/perimeter-monitor.log
+```
+
+Deployment workflow:
+1. `php artisan perimeter:terminate` - Gracefully stop monitoring
+2. Deploy application updates
+3. Supervisor automatically restarts monitoring
+
 ### Reporting
 
 Generate detailed security reports with flexible filtering:

--- a/src/Commands/PerimeterMonitor.php
+++ b/src/Commands/PerimeterMonitor.php
@@ -3,6 +3,7 @@
 namespace Prahsys\Perimeter\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
 use Prahsys\Perimeter\Contracts\SecurityMonitoringServiceInterface;
 
 class PerimeterMonitor extends Command
@@ -128,6 +129,13 @@ class PerimeterMonitor extends Command
 
         // Main monitoring loop - run indefinitely or until end time
         while ($endTime === null || now()->lessThan($endTime)) {
+            // Check for termination signal
+            if ($this->shouldTerminate()) {
+                $this->newLine();
+                $this->info('Termination signal received. Shutting down gracefully...');
+                break;
+            }
+
             // Check if we've been running for at least $checkInterval seconds
             if (time() - $lastCheck >= $checkInterval) {
                 $hasNewEvents = false;
@@ -194,5 +202,13 @@ class PerimeterMonitor extends Command
             'info', 'low' => 'green',
             default => 'white',
         };
+    }
+
+    /**
+     * Check if monitoring should terminate
+     */
+    protected function shouldTerminate(): bool
+    {
+        return Cache::has('perimeter:terminate');
     }
 }

--- a/src/Commands/PerimeterTerminate.php
+++ b/src/Commands/PerimeterTerminate.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Prahsys\Perimeter\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\Process\Process;
+
+class PerimeterTerminate extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'perimeter:terminate {--wait=5 : Wait time in seconds for graceful shutdown}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Terminate the perimeter monitoring daemon';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $waitTime = (int) $this->option('wait');
+
+        $this->info('Terminating perimeter monitoring...');
+
+        // Signal all running monitoring processes to terminate
+        $terminated = $this->signalTermination();
+
+        if (! $terminated) {
+            $this->warn('No active monitoring processes found.');
+
+            return 0;
+        }
+
+        $this->info("Waiting up to {$waitTime} seconds for graceful shutdown...");
+
+        // Wait for processes to terminate gracefully
+        $startTime = time();
+        while ((time() - $startTime) < $waitTime) {
+            if (! $this->hasActiveMonitoring()) {
+                $this->info('All monitoring processes terminated gracefully.');
+
+                return 0;
+            }
+            sleep(1);
+        }
+
+        // Force kill if still running
+        $this->warn('Graceful shutdown timeout reached. Force terminating...');
+        $forceKilled = $this->forceTerminate();
+
+        if ($forceKilled) {
+            $this->info('Monitoring processes force terminated.');
+        } else {
+            $this->error('Failed to terminate some monitoring processes.');
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Signal termination to monitoring processes
+     */
+    protected function signalTermination(): bool
+    {
+        $terminated = false;
+
+        // Set termination signal in cache (similar to Horizon)
+        Cache::forever('perimeter:terminate', time());
+
+        // Find and signal PHP processes running perimeter:monitor
+        $processes = $this->findMonitoringProcesses();
+
+        foreach ($processes as $pid) {
+            $this->line("Sending SIGTERM to process {$pid}");
+
+            // Send SIGTERM for graceful shutdown
+            $process = new Process(['kill', '-TERM', $pid]);
+            $process->run();
+
+            if ($process->isSuccessful()) {
+                $terminated = true;
+            }
+        }
+
+        return $terminated;
+    }
+
+    /**
+     * Force terminate monitoring processes
+     */
+    protected function forceTerminate(): bool
+    {
+        $processes = $this->findMonitoringProcesses();
+        $allKilled = true;
+
+        foreach ($processes as $pid) {
+            $this->line("Force killing process {$pid}");
+
+            // Send SIGKILL
+            $process = new Process(['kill', '-KILL', $pid]);
+            $process->run();
+
+            if (! $process->isSuccessful()) {
+                $allKilled = false;
+                $this->error("Failed to kill process {$pid}");
+            }
+        }
+
+        // Clear the termination signal
+        Cache::forget('perimeter:terminate');
+
+        return $allKilled;
+    }
+
+    /**
+     * Find running monitoring processes
+     */
+    protected function findMonitoringProcesses(): array
+    {
+        // Look for PHP processes running perimeter:monitor
+        $process = new Process(['pgrep', '-f', 'perimeter:monitor']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return [];
+        }
+
+        $pids = array_filter(array_map('trim', explode("\n", $process->getOutput())));
+
+        // Filter out the current process
+        $currentPid = getmypid();
+
+        return array_filter($pids, function ($pid) use ($currentPid) {
+            return $pid != $currentPid && is_numeric($pid);
+        });
+    }
+
+    /**
+     * Check if there are active monitoring processes
+     */
+    protected function hasActiveMonitoring(): bool
+    {
+        return ! empty($this->findMonitoringProcesses());
+    }
+}

--- a/src/PerimeterServiceProvider.php
+++ b/src/PerimeterServiceProvider.php
@@ -15,6 +15,7 @@ use Prahsys\Perimeter\Commands\PerimeterMonitor;
 use Prahsys\Perimeter\Commands\PerimeterPrune;
 use Prahsys\Perimeter\Commands\PerimeterReport;
 use Prahsys\Perimeter\Commands\PerimeterSeedTestData;
+use Prahsys\Perimeter\Commands\PerimeterTerminate;
 use Prahsys\Perimeter\Contracts\FirewallServiceInterface;
 use Prahsys\Perimeter\Contracts\IntrusionPreventionInterface;
 use Prahsys\Perimeter\Contracts\MonitorServiceInterface;
@@ -151,6 +152,7 @@ class PerimeterServiceProvider extends ServiceProvider
             $this->commands([
                 PerimeterAudit::class,
                 PerimeterMonitor::class,
+                PerimeterTerminate::class,
                 PerimeterReport::class,
                 PerimeterHealth::class,
                 PerimeterInstall::class,


### PR DESCRIPTION
Implements a terminate command for graceful shutdown of perimeter:monitor
processes during deployments. The command provides clean daemon management for
supervisor-controlled monitoring services.

**Features:**
- Graceful shutdown with configurable wait time (default: 5 seconds)
- Process discovery using pgrep for running perimeter:monitor instances
- SIGTERM signal for graceful shutdown, SIGKILL for force termination
- Cache-based termination signaling for cross-process communication
- Enhanced PerimeterMonitor to check for termination signals in monitoring loop

**Usage:**
- `php artisan perimeter:terminate` - Gracefully stop monitoring processes
- `php artisan perimeter:terminate --wait=10` - Custom graceful shutdown timeout
- Ideal for deployment scripts with supervisor auto-restart

**Documentation:**
- Added daemon management section to README with supervisor configuration
- Included deployment workflow and production usage examples
- Covers integration with supervisor for automatic service restart

This enables reliable deployment workflows where monitoring can be cleanly stopped
and automatically restarted by supervisor after deployments complete.
